### PR TITLE
Merge controller_data_defaults when loading payment methods.

### DIFF
--- a/payment_controller_data.info
+++ b/payment_controller_data.info
@@ -3,5 +3,6 @@ description = Store payment's $method->controller_data in a serialized column.
 core = 7.x
 php = 5.6
 
+dependencies[] = little_helpers (>=1.4)
 dependencies[] = payment
 

--- a/payment_controller_data.module
+++ b/payment_controller_data.module
@@ -1,1 +1,12 @@
 <?php
+
+use Drupal\little_helpers\ArrayConfig;
+
+/**
+ * Implements hook_payment_method_load().
+ */
+function payment_controller_data_payment_method_load($methods) {
+  foreach ($methods as $method) {
+    ArrayConfig::mergeDefaults($method->controller_data, $method->controller->controller_data_defaults);
+  }
+}


### PR DESCRIPTION
New configuration variables might be added after a payment method was created. So it’s prudent to load all the default values whenever a payment method is loaded.

New dependency: little_helpers (>=1.4)